### PR TITLE
URL application changed

### DIFF
--- a/manifest.jps
+++ b/manifest.jps
@@ -74,7 +74,7 @@ actions:
     deploy:
       name: Ghost-latest
       context: ROOT
-      archive: https://ghost.org/zip/ghost-latest.zip
+      archive: https://download.jelastic.com/public.php?service=files&t=89c95da37d36c166e32bc0edcd32b38d&download
 
   deployHomeDir:
     cmd[cp]:


### PR DESCRIPTION
Ghost latest version URL https://ghost.org/zip/ghost-latest.zip leads to obsolete ghost version 1.26.2. So it was replaced with version 3.0.3